### PR TITLE
ajout de swagger2 pour documenter les endpoints de api patient

### DIFF
--- a/patient/pom.xml
+++ b/patient/pom.xml
@@ -34,6 +34,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-thymeleaf</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-boot-starter</artifactId>
+			<version>3.0.0</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -96,6 +101,7 @@
 						<exclude>com/mediscreen/patient/utils/*LightPatient.class*</exclude>
 						<exclude>com/mediscreen/patient/exception/*PatientNotFoundException.class*</exclude>
 						<exclude>com/mediscreen/patient/repository/*PatientRepository.class*</exclude>
+						<exclude>com/mediscreen/patient/configuration/*SwaggerConfig.class*</exclude>
 						<exclude>com/mediscreen/patient/*PatientApplication.class*</exclude>
 					</excludes>
 				</configuration>

--- a/patient/src/main/java/com/mediscreen/patient/PatientApplication.java
+++ b/patient/src/main/java/com/mediscreen/patient/PatientApplication.java
@@ -2,7 +2,9 @@ package com.mediscreen.patient;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
+@EnableSwagger2
 @SpringBootApplication
 public class PatientApplication {
 

--- a/patient/src/main/java/com/mediscreen/patient/configuration/SwaggerConfig.java
+++ b/patient/src/main/java/com/mediscreen/patient/configuration/SwaggerConfig.java
@@ -1,0 +1,21 @@
+package com.mediscreen.patient.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.mediscreen.patient"))
+                .paths(PathSelectors.any())
+                .build();
+    }
+}

--- a/patient/src/main/resources/application.properties
+++ b/patient/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.application.name=patient
 server.port=8081
 spring.data.mongodb.uri=mongodb+srv://fercakflorian:1234@cluster.hqp8whj.mongodb.net/PreventDiabetes.patient
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher

--- a/view/pom.xml
+++ b/view/pom.xml
@@ -50,7 +50,13 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-swagger2</artifactId>
+            <version>3.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
 	<dependencyManagement>
 		<dependencies>
 			<dependency>


### PR DESCRIPTION
Documentation des endpoints de l'API patient disponible ici : http://localhost:8081/swagger-ui/