### PR TITLE
redirection urls des boutons cancel

### DIFF
--- a/view/src/main/java/com/mediscreen/view/controller/ViewController.java
+++ b/view/src/main/java/com/mediscreen/view/controller/ViewController.java
@@ -135,7 +135,7 @@ public class ViewController {
         } else {
             PatientBean patientBean = new PatientBean(patient.getId(), patient.getFirstName(), patient.getLastName(), patient.getFamily(), patient.getGiven(), patient.getDob(), patient.getSex(), patient.getAddress(), patient.getPhone());
             microservicePatientProxy.updatePatient(patientBean, id);
-            return "redirect:/patient/list";
+            return "redirect:/patient/" + patient.getId();
         }
     }
 

--- a/view/src/main/resources/templates/note/update.html
+++ b/view/src/main/resources/templates/note/update.html
@@ -52,9 +52,8 @@
             </div>
             <div class="form-group">
                 <div class="col-sm-12">
-                    <button type="submit" class="btn btn-danger btn-sm" formmethod="get"
-                            formaction="/">Cancel
-                    </button>
+                    <a th:href="@{/patient/{id}(id=${note.patientId})}" class="btn btn-danger btn-sm" formmethod="get">Cancel
+                    </a>
                     <button type="submit" class="btn btn-primary btn-sm" formmethod="post">Update Note
                     </button>
                 </div>

--- a/view/src/main/resources/templates/update.html
+++ b/view/src/main/resources/templates/update.html
@@ -25,17 +25,17 @@
               method="post"
               class="form-horizontal" style="width: 100%">
             <div class="form-group">
-                <label for="firstName" class="col-sm-2 control-label">FirstName</label>
-                <div class="col-sm-10">
-                    <input type="text" id="firstName" th:field="*{firstName}" th:value="${patient.firstName}">
-                    <p class="text-danger" th:if="${#fields.hasErrors('firstName')}" th:errors="*{firstName}"></p>
-                </div>
-            </div>
-            <div class="form-group">
                 <label for="type" class="col-sm-2 control-label">LastName</label>
                 <div class="col-sm-10">
                     <input type="text" id="type" th:field="*{lastName}" th:value="${patient.lastName}">
                     <p class="text-danger" th:if="${#fields.hasErrors('lastName')}" th:errors="*{lastName}"></p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="firstName" class="col-sm-2 control-label">FirstName</label>
+                <div class="col-sm-10">
+                    <input type="text" id="firstName" th:field="*{firstName}" th:value="${patient.firstName}">
+                    <p class="text-danger" th:if="${#fields.hasErrors('firstName')}" th:errors="*{firstName}"></p>
                 </div>
             </div>
             <div class="form-group">
@@ -94,9 +94,8 @@
             </div>
             <div class="form-group">
                 <div class="col-sm-12">
-                    <button type="submit" class="btn btn-danger btn-sm" formmethod="get"
-                            formaction="/">Cancel
-                    </button>
+                    <a th:href="@{/patient/{id}(id=${patient.id})}" class="btn btn-danger btn-sm" formmethod="get">Cancel
+                    </a>
                     <button type="submit" class="btn btn-primary btn-sm" formmethod="post"
                             th:formaction="@{/patient/update/{id}(id=${patient.id})}">Update Patient
                     </button>


### PR DESCRIPTION
Les actions suivantes ont été réalisées : 
 - bouton CANCEL de la page de mise à jour d'une note redirige vers la page du dossier patient
 - bouton CANCEL de la page de mise à jour d'un patient redirige vers la page du dossier patient
 - bouton UPDATE PATIENT de la page de mise à jour d'un patient redirige vers la page du dossier patient